### PR TITLE
fix: increase str[] size

### DIFF
--- a/nyx.h
+++ b/nyx.h
@@ -342,7 +342,7 @@ enum nyx_cpu_type{
 	 
 static int is_nyx_vcpu(void){
   unsigned long eax,ebx,ecx,edx;
-  char str[8];
+  char str[16];
   cpuid(0x80000004,eax,ebx,ecx,edx);	
 
   for(int j=0;j<4;j++){
@@ -355,7 +355,7 @@ static int is_nyx_vcpu(void){
 
 static int get_nyx_cpu_type(void){
 	unsigned long eax,ebx,ecx,edx;
-  char str[8];
+  char str[16];
   cpuid(0x80000004,eax,ebx,ecx,edx);	
 
   for(int j=0;j<4;j++){


### PR DESCRIPTION
When str is char str[8], reading str[8] and writing to str[8] = 0; looks weird.
Although there's an implicit space in the stack.