### PR TITLE
Fix register assignments for hypercall entries.

### DIFF
--- a/nyx.h
+++ b/nyx.h
@@ -131,40 +131,28 @@ typedef struct{
 #define KAFL_MODE_16	2
 
 #if defined(__i386__)
-#define KAFL_HYPERCALL_NO_PT(_rbx, _rcx) ({ \
-	uint32_t _rax = HYPERCALL_KAFL_RAX_ID_VMWARE; \
+#define KAFL_HYPERCALL_NO_PT(_ebx, _ecx) ({ \
+	uint32_t _eax = HYPERCALL_KAFL_RAX_ID_VMWARE; \
 	do{ \
-	uint32_t _rdx = VMWARE_PORT; \
 	asm volatile( \
-		"movl %1, %%ecx;" \
-		"movl %2, %%ebx;" \
-		"movl %3, %%eax;" \
-		"movl %4, %%edx;" \
 		"outl %%eax, %%dx;" \
-		"movl %%eax, %0;" \
-	: "=a" (_rax) \
-	: "g" (_rcx), "r" (_rbx), "g" (_rax), "g" (_rdx) \
-	: "ecx", "ebx", "edx" \
+	: "=a" (_eax) \
+	: "a" (_eax), "b" (_ebx), "c" (_ecx), "d" (VMWARE_PORT) \
 	); \
 	} while(0); \
-	_rax; \
+	_eax; \
 })
 
-#define KAFL_HYPERCALL_PT(_rbx, _rcx) ({ \
-	uint32_t _rax = HYPERCALL_KAFL_RAX_ID; \
+#define KAFL_HYPERCALL_PT(_ebx, _ecx) ({ \
+	uint32_t _eax = HYPERCALL_KAFL_RAX_ID; \
 	do{ \
 	asm volatile( \
-		"movl %1, %%ecx;" \
-		"movl %2, %%ebx;" \
-		"movl %3, %%eax;" \
 		"vmcall;" \
-		"movl %%eax, %0;" \
-	: "=a" (_rax) \
-	: "r" (_rcx), "r" (_rbx), "r" (_rax) \
-	: "ecx", "ebx" \
+	: "=a" (_eax) \
+	: "a" (_eax), "b" (_ebx), "c" (_ecx), \
 	); \
 	} while(0); \
-	_rax; \
+	_eax; \
 })
 
 #else
@@ -172,17 +160,10 @@ typedef struct{
 #define KAFL_HYPERCALL_NO_PT(_rbx, _rcx) ({ \
 	uint64_t _rax = HYPERCALL_KAFL_RAX_ID_VMWARE; \
 	do{ \
-	uint64_t _rdx = VMWARE_PORT; \
 	asm volatile( \
-		"movq %1, %%rcx;" \
-		"movq %2, %%rbx;" \
-		"movq %3, %%rax;" \
-		"movq %4, %%rdx;" \
 		"outl %%eax, %%dx;" \
-		"movq %%rax, %0;" \
 	: "=a" (_rax) \
-	: "r" (_rcx), "r" (_rbx), "r" (_rax), "r" (_rdx) \
-	: "rcx", "rbx", "rdx" \
+	: "a" (_rax), "b" (_rbx), "c" (_rcx), "d" (VMWARE_PORT) \
 	); \
 	} while(0); \
 	_rax; \
@@ -192,14 +173,9 @@ typedef struct{
 	uint64_t _rax = HYPERCALL_KAFL_RAX_ID; \
 	do{ \
 	asm volatile( \
-		"movq %1, %%rcx;" \
-		"movq %2, %%rbx;" \
-		"movq %3, %%rax;" \
 		"vmcall;" \
-		"movq %%rax, %0;" \
 	: "=a" (_rax) \
-	: "r" (_rcx), "r" (_rbx), "r" (_rax) \
-	: "rcx", "rbx" \
+	: "a" (_rax),  "b" (_rbx), "c" (_rcx),\
 	); \
 	} while(0); \
 	_rax; \

--- a/nyx.h
+++ b/nyx.h
@@ -136,8 +136,9 @@ typedef struct{
 	do{ \
 	asm volatile( \
 		"outl %%eax, %%dx;" \
-	: "=a" (_eax) \
-	: "a" (_eax), "b" (_ebx), "c" (_ecx), "d" (VMWARE_PORT) \
+	: "+a" (_eax) \
+	: "b" (_ebx), "c" (_ecx), "d" (VMWARE_PORT) \
+	: "cc", "memory" \
 	); \
 	} while(0); \
 	_eax; \
@@ -148,8 +149,9 @@ typedef struct{
 	do{ \
 	asm volatile( \
 		"vmcall;" \
-	: "=a" (_eax) \
-	: "a" (_eax), "b" (_ebx), "c" (_ecx), \
+	: "+a" (_eax) \
+	: "b" (_ebx), "c" (_ecx) \
+	: "cc", "memory" \
 	); \
 	} while(0); \
 	_eax; \
@@ -162,8 +164,9 @@ typedef struct{
 	do{ \
 	asm volatile( \
 		"outl %%eax, %%dx;" \
-	: "=a" (_rax) \
-	: "a" (_rax), "b" (_rbx), "c" (_rcx), "d" (VMWARE_PORT) \
+	: "+a" (_rax) \
+	: "b" (_rbx), "c" (_rcx), "d" (VMWARE_PORT) \
+	: "cc", "memory" \
 	); \
 	} while(0); \
 	_rax; \
@@ -174,8 +177,9 @@ typedef struct{
 	do{ \
 	asm volatile( \
 		"vmcall;" \
-	: "=a" (_rax) \
-	: "a" (_rax),  "b" (_rbx), "c" (_rcx),\
+	: "+a" (_rax) \
+	: "b" (_rbx), "c" (_rcx) \
+	: "cc", "memory" \
 	); \
 	} while(0); \
 	_rax; \


### PR DESCRIPTION
I experienced some issues with the code-generation due to missing clobbers, and fixed up the asm parameter constraints to stop this from happening. (See commit messages for more details).