### PR TITLE
Fixed heap OOB read in ld_preload_fuzz.so:select()

### DIFF
--- a/packer/linux_x86_64-userspace/src/netfuzz/inject.c
+++ b/packer/linux_x86_64-userspace/src/netfuzz/inject.c
@@ -70,6 +70,8 @@ static void nyx_assert(bool exp, const char* func) {
 #define DEBUG(f_, ...) 
 #endif
 
+#define howmany(x,y)	(((x)+((y)-1))/(y))
+
 //extern interpreter_t* vm;
 
 bool is_target_port(uint16_t port){
@@ -620,7 +622,8 @@ int select(int nfds, fd_set *readfds, fd_set *writefds,
 	fd_set old_readfds;
 
 	if(readfds){
-		memcpy(&old_readfds, readfds, sizeof(fd_set));
+		size_t sz = howmany(nfds, NFDBITS) * sizeof(fd_mask);
+		memcpy(&old_readfds, readfds, sz);
 	}
 
 	int ret = real_select(nfds, readfds, writefds, exceptfds, &timeout_new);


### PR DESCRIPTION
Some applications (e.g. OpenSSH) may not allocate a full fd_set, but rather just enough to fit nfds bits.

This behavior is observed in the OpenSSH version included with ProFuzzBench:
https://github.com/vegard/openssh-portable/blob/58b8cfa2a062b72139d7229ae8de567f55776f24/sshd.c#L1125

It is thus only safe to copy as many `fd_mask` chunks from the input as guaranteed by the given `nfds` argument.