### PR TITLE
enable userspace port I/O for hypercalls in guest

### DIFF
--- a/linux_initramfs/pack.sh
+++ b/linux_initramfs/pack.sh
@@ -32,8 +32,8 @@ fi
 cd ../packer/linux_x86_64-userspace/
 sh compile_loader.sh
 cd -
-cp ../packer/linux_x86_64-userspace/bin64/loader rootTemplate/loader
-chmod +x rootTemplate/loader
+cp ../packer/linux_x86_64-userspace/bin64/{loader,portio-enable} rootTemplate/
+chmod +x rootTemplate/{loader,portio-enable}
 mkdir rootTemplate/lib/
 mkdir rootTemplate/lib64/
 mkdir rootTemplate/lib/i386-linux-gnu/
@@ -71,4 +71,4 @@ rm -r ./init/
 
 rm -r rootTemplate/lib/
 rm -r rootTemplate/lib64/
-rm rootTemplate/loader
+rm rootTemplate/{loader,portio-enable}

--- a/linux_initramfs/rootTemplate/init_template
+++ b/linux_initramfs/rootTemplate/init_template
@@ -1,4 +1,11 @@
 #!/bin/sh
+
+# enable port I/O from userspace for NYX hypercalls, then re-exec this script
+if [ "$PORTIO_ENABLED" != "1" ]; then
+  export PORTIO_ENABLED=1
+  exec /portio-enable /init
+fi
+
 mount -t proc none /proc
 mount -t sysfs none /sys
 mount -t debugfs none /sys/kernel/debug

--- a/packer/linux_x86_64-userspace/compile_32.sh
+++ b/packer/linux_x86_64-userspace/compile_32.sh
@@ -50,3 +50,4 @@ gcc -O0 -m32 -Werror -DNO_PT_NYX src/htools/hpush.c -I../../ -o bin32/hpush_no_p
 
 # loader support both modes (PT & NO-PT)
 #gcc -O0 -m32 -static -Werror src/loader.c -I../../agents -o bin32/loader
+gcc -O0 -m32 -static -Werror src/portio-enable.c -I../../ -o bin32/portio-enable

--- a/packer/linux_x86_64-userspace/compile_64.sh
+++ b/packer/linux_x86_64-userspace/compile_64.sh
@@ -50,3 +50,4 @@ gcc -O0 -m64 -Werror -DNO_PT_NYX src/htools/hpush.c -I../../ -o bin64/hpush_no_p
 
 # loader support both modes (PT & NO-PT)
 gcc -O0 -m64 -static -Werror src/loader.c -I../../ -o bin64/loader
+gcc -O0 -m64 -static -Werror src/portio-enable.c -I../../ -o bin64/portio-enable

--- a/packer/linux_x86_64-userspace/compile_loader.sh
+++ b/packer/linux_x86_64-userspace/compile_loader.sh
@@ -1,2 +1,3 @@
 mkdir -p bin64/
 gcc -O0 -m64 -static -Werror src/loader.c -I../../ -o bin64/loader
+gcc -O0 -m64 -static -Werror src/portio-enable.c -I../../ -o bin64/portio-enable

--- a/packer/linux_x86_64-userspace/src/portio-enable.c
+++ b/packer/linux_x86_64-userspace/src/portio-enable.c
@@ -1,0 +1,11 @@
+#include <err.h>
+#include <unistd.h>
+#include <sys/io.h>
+#include "nyx.h"
+
+int main(int argc, char **argv) {
+	if (ioperm(VMWARE_PORT, 4, 1))
+		err(1, "ioperm");
+	execvp(argv[1], argv+1);
+	err(1, "execvp");
+}


### PR DESCRIPTION
Use `ioperm()` to explicitly allow port I/O to the port used for Nyx hypercalls. With this, the host kernel no longer needs to enable `enable_vmware_backdoor=y`.

Benefits:

 - It avoids needing to change system-wide host configuration.
 - It lets KVM avoid intercepting guest #GP and decoding every instruction that hits #GP.

Downsides:

 - Some stuff in the guest kernel will hit slowpaths; in particular, the syscall return path will probably run a few instructions more (`tss_update_io_bitmap()`).

Switching between multiple tasks with separately-created `ioperm()` bitmasks would probably be slow because we'd hit the `memcpy()` in `tss_copy_io_bitmap()`, but as long as we just set up a single `ioperm()` bitmask in init, that shouldn't happen.

With this patch applied, I can use `afl-fuzz` in Nyx mode without enabling `enable_vmware_backdoor`.